### PR TITLE
Corrected `__init__.py`

### DIFF
--- a/tests/test_vtkgrid.py
+++ b/tests/test_vtkgrid.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from vtktonumpy.vtkgrid import VTKGrid
+from vtktonumpy import VTKGrid
 from numpy import all
 
 @pytest.fixture

--- a/tests/test_vtkreader.py
+++ b/tests/test_vtkreader.py
@@ -5,7 +5,7 @@ from numpy import all
 from vtk import vtkXMLRectilinearGridWriter
 from conftest import addVectorData,addScalarData
 
-from vtktonumpy.vtkreader import VTKReader
+from vtktonumpy import VTKReader
 
 SCALAR_NAME="S"
 VECTOR_NAME="V"

--- a/vtktonumpy/__init__.py
+++ b/vtktonumpy/__init__.py
@@ -1,0 +1,2 @@
+from .vtkgrid import VTKGrid
+from .vtkreader import VTKReader


### PR DESCRIPTION
`__init__.py` now contains imports so python code can run like this:
```
import vtktonumpy

reader=vtktonumpy.VTKReader(...)
.
.
.
```